### PR TITLE
Add translation check for missing Russian strings

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,3 +38,15 @@ jobs:
           node-version: "20.x"
       - run: npm install
       - run: npm run lint
+
+  check-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+      - run: npm install
+      - run: npm run check-translations

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check-types": "tsc --noEmit",
     "format": "prettier . --write",
     "check-format": "prettier --check .",
-    "all-checks": "npm run check-format && npm run check-types && npm run lint"
+    "all-checks": "npm run check-format && npm run check-types && npm run lint",
+    "check-translations": "tsx scripts/check-translations.ts"
   },
   "dependencies": {
     "@aws-amplify/ui": "^6.7.0",

--- a/scripts/check-translations.ts
+++ b/scripts/check-translations.ts
@@ -121,6 +121,11 @@ function analyzeFile(filePath: string) {
 
 walk(path.join(__dirname, "..", "src"));
 
+console.log("Translatable strings found:");
+collected.forEach((text) => {
+  console.log(` - ${text}`);
+});
+
 const missing: string[] = [];
 collected.forEach((text) => {
   if (!Object.prototype.hasOwnProperty.call(russian, text)) {

--- a/scripts/check-translations.ts
+++ b/scripts/check-translations.ts
@@ -123,7 +123,8 @@ walk(path.join(__dirname, "..", "src"));
 
 console.log("Translatable strings found:");
 collected.forEach((text) => {
-  console.log(` - ${text}`);
+  const translation = russian[text];
+  console.log(` - ${text} -> ${translation ?? "(missing)"}`);
 });
 
 const missing: string[] = [];

--- a/scripts/check-translations.ts
+++ b/scripts/check-translations.ts
@@ -1,0 +1,139 @@
+import fs from "fs";
+import path from "path";
+import ts from "typescript";
+import translations from "../src/components/translations";
+
+const russian =
+  (translations as Record<string, Record<string, string>>).ru || {};
+
+const collected = new Set<string>();
+
+function walk(dir: string) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath);
+    } else if (
+      entry.isFile() &&
+      (fullPath.endsWith(".ts") || fullPath.endsWith(".tsx"))
+    ) {
+      analyzeFile(fullPath);
+    }
+  }
+}
+
+function analyzeFile(filePath: string) {
+  const content = fs.readFileSync(filePath, "utf8");
+  const source = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  function visit(node: ts.Node) {
+    if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
+      const tagName = node.tagName.getText();
+      if (tagName === "TranslatableText") {
+        let text: string | undefined;
+        let id: string | undefined;
+        let expectTranslation = true;
+        node.attributes.properties.forEach((attr) => {
+          if (ts.isJsxAttribute(attr) && attr.initializer) {
+            const name = attr.name.getText();
+            if (
+              (name === "text" ||
+                name === "id" ||
+                name === "expectTranslation") &&
+              ts.isJsxExpression(attr.initializer)
+            ) {
+              const expr = attr.initializer.expression;
+              if (
+                name === "expectTranslation" &&
+                expr &&
+                expr.kind === ts.SyntaxKind.FalseKeyword
+              ) {
+                expectTranslation = false;
+              }
+              if (name === "text" || name === "id") {
+                if (expr && ts.isStringLiteral(expr)) {
+                  if (name === "text") text = expr.text;
+                  else id = expr.text;
+                }
+              }
+            } else if (
+              name === "text" &&
+              ts.isStringLiteral(attr.initializer)
+            ) {
+              text = attr.initializer.text;
+            } else if (name === "id" && ts.isStringLiteral(attr.initializer)) {
+              id = attr.initializer.text;
+            } else if (
+              name === "expectTranslation" &&
+              ts.isStringLiteral(attr.initializer)
+            ) {
+              expectTranslation = attr.initializer.text !== "false";
+            }
+          }
+        });
+        if (expectTranslation) {
+          if (id) collected.add(id);
+          else if (text) collected.add(text);
+        }
+      }
+    } else if (ts.isCallExpression(node)) {
+      const expr = node.expression.getText();
+      if (expr === "useTranslatedText" || expr === "getTranslatedText") {
+        const arg = node.arguments[0];
+        if (arg && ts.isObjectLiteralExpression(arg)) {
+          let text: string | undefined;
+          let id: string | undefined;
+          let expectTranslation = true;
+          for (const prop of arg.properties) {
+            if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+              const name = prop.name.text;
+              if (name === "expectTranslation") {
+                if (prop.initializer.kind === ts.SyntaxKind.FalseKeyword)
+                  expectTranslation = false;
+              } else if (name === "text" || name === "id") {
+                if (ts.isStringLiteral(prop.initializer)) {
+                  if (name === "text") text = prop.initializer.text;
+                  else id = prop.initializer.text;
+                }
+              }
+            }
+          }
+          if (expectTranslation) {
+            if (id) collected.add(id);
+            else if (text) collected.add(text);
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+}
+
+walk(path.join(__dirname, "..", "src"));
+
+const missing: string[] = [];
+collected.forEach((text) => {
+  if (!Object.prototype.hasOwnProperty.call(russian, text)) {
+    missing.push(text);
+  }
+});
+
+if (missing.length > 0) {
+  console.error("Missing Russian translations for the following strings:");
+  for (const m of missing) {
+    console.error(` - ${m}`);
+  }
+  process.exit(1);
+} else {
+  console.log("All translatable text has Russian translations.");
+}

--- a/src/components/translations/russian.tsx
+++ b/src/components/translations/russian.tsx
@@ -117,8 +117,7 @@ const translations: Record<string, string> = {
   "Report Issue": "Сообщить о проблеме",
   "Which parts of the information have an issue?":
     "В какой информации присутствует проблема?",
-  "Please describe the issue below (Please don't enter any private information)":
-    "Опишите проблему ниже (пожалуйста, не вводите личную информацию)",
+  "Please describe the issue below": "Опишите проблему ниже",
   Send: "Отправить",
   "All service locations": "Все филиалы",
   "All Services": "Все филиалы",


### PR DESCRIPTION
## Summary
- add script to statically collect translatable strings and ensure Russian translations exist
- wire script into npm and CI workflow

## Testing
- `npm run check-translations`
- `npm run all-checks`


------
https://chatgpt.com/codex/tasks/task_e_68b1408a055c83279c25bde585247ee3