### PR TITLE
Fix lint regression by renaming previous params utility

### DIFF
--- a/src/app/[route]/@mapContainer/[locationSlugOrPersonalCareSubCategory]/page.tsx
+++ b/src/app/[route]/@mapContainer/[locationSlugOrPersonalCareSubCategory]/page.tsx
@@ -16,7 +16,7 @@ import {
   fetchLocationsDetailData,
 } from "../../../../components/streetlives-api-service";
 import { getMapContainerData } from "../../../../components/map-container-component";
-import { usePreviousParams } from "@/components/use-previous-params";
+import { getPreviousParams } from "@/components/use-previous-params";
 import {
   isOnLocationDetailPage,
   redirectIfNearbyAndIfLatitudeAndLongitudeIsNotSet,
@@ -30,7 +30,7 @@ export default async function MapDetail({
   searchParams: SearchParams;
   params: SubRouteParams;
 }) {
-  const previousParams = usePreviousParams();
+  const previousParams = getPreviousParams();
   try {
     if (!isOnLocationDetailPage(params)) {
       // validate

--- a/src/app/[route]/@sidePanel/[locationSlugOrPersonalCareSubCategory]/page.tsx
+++ b/src/app/[route]/@sidePanel/[locationSlugOrPersonalCareSubCategory]/page.tsx
@@ -18,7 +18,6 @@ import {
 } from "../../../../components/streetlives-api-service";
 import { SidePanelComponent } from "../../../../components/side-panel-component";
 import LocationDetailComponent from "../../../../components/location-detail-component";
-import { usePreviousParams } from "@/components/use-previous-params";
 import { getSidePanelComponentData } from "@/components/get-side-panel-component-data";
 import {
   isOnLocationDetailPage,
@@ -36,7 +35,6 @@ export default async function LocationDetail({
   params: SubRouteParams;
   searchParams: SearchParams;
 }) {
-  const previousParams = usePreviousParams();
   try {
     if (!isOnLocationDetailPage(params)) {
       // validate

--- a/src/components/use-previous-params.ts
+++ b/src/components/use-previous-params.ts
@@ -10,7 +10,7 @@ export interface PreviousParams {
   params: RouteParams;
 }
 
-export function usePreviousParams(): PreviousParams | null {
+export function getPreviousParams(): PreviousParams | null {
   const cookie = cookies().get(LAST_SET_PARAMS_COOKIE_NAME);
   console.log("cookie", cookie);
   if (cookie && cookie.value) {


### PR DESCRIPTION
## Summary
- rename server-side `usePreviousParams` to `getPreviousParams`
- remove unused previous params hook from side panel page

## Testing
- `npx prettier src/components/use-previous-params.ts "src/app/[route]/@mapContainer/[locationSlugOrPersonalCareSubCategory]/page.tsx" "src/app/[route]/@sidePanel/[locationSlugOrPersonalCareSubCategory]/page.tsx" --check`
- `npm run lint`
- `npm run check-types`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b14a71c408832786925b78f66d02a6