### PR TITLE
feat: guarded DOM ops to prevent white-screen under translation (flagged)

### DIFF
--- a/src/app/[route]/layout.tsx
+++ b/src/app/[route]/layout.tsx
@@ -20,6 +20,7 @@ import { SearchProvider } from "@/components/search-context";
 import { MainComponent } from "@/components/main-component";
 import GTranslateWrapper from "@/components/gtranslate-wrapper";
 import { GeoCoordinatesProvider } from "@/components/geo-context";
+import GTProdGuardScript from "@/components/gt-prod-guard-script";
 
 export default async function LocationsLayout(props: {
   mapContainer: React.ReactNode;
@@ -35,6 +36,7 @@ export default async function LocationsLayout(props: {
 
   return (
     <>
+      <GTProdGuardScript />
       <GTranslateWrapper />
       <span>
         {RESOURCE_ROUTES.includes(route) ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { CookiesProvider } from "next-client-cookies/server";
 import Script from "next/script";
 import { Toaster } from "sonner";
 import QueryClientProvider from "@/app/QueryClientProvider";
+import GTProdGuardScript from "@/components/gt-prod-guard-script";
 
 export const viewport: Viewport = {
   themeColor: "#FFD54F",
@@ -41,6 +42,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&display=swap"
           rel="stylesheet"
         />
+        <GTProdGuardScript />
       </head>
 
       <Script

--- a/src/components/gt-prod-guard-script.tsx
+++ b/src/components/gt-prod-guard-script.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable @next/next/no-before-interactive-script-outside-document */
+import Script from "next/script";
+
+const GT_PROD_GUARD_ENABLED = process.env.NEXT_PUBLIC_GT_PROD_GUARD === "true";
+
+const GT_PROD_GUARD_SCRIPT = `(() => {
+  if (typeof window === "undefined" || typeof Node === "undefined") {
+    return;
+  }
+
+  const globalScope = window;
+
+  if (globalScope.__gtProdGuardInstalled__) {
+    return;
+  }
+
+  globalScope.__gtProdGuardInstalled__ = true;
+
+  const warnOnce = () => {
+    if (globalScope.__gtProdGuardWarned__) {
+      return;
+    }
+
+    globalScope.__gtProdGuardWarned__ = true;
+    console.warn(
+      "[YourPeer] Guarded DOM operations: prevented removeChild/insertBefore on nodes that are not children of the target parent.",
+    );
+  };
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  const originalInsertBefore = Node.prototype.insertBefore;
+
+  Node.prototype.removeChild = function removeChildGuard(child) {
+    if (!child || child.parentNode !== this) {
+      warnOnce();
+      return child ?? null;
+    }
+
+    return originalRemoveChild.call(this, child);
+  };
+
+  Node.prototype.insertBefore = function insertBeforeGuard(newNode, referenceNode) {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      warnOnce();
+      return newNode;
+    }
+
+    return originalInsertBefore.call(this, newNode, referenceNode);
+  };
+})();`;
+
+declare global {
+  interface Window {
+    __gtProdGuardInstalled__?: boolean;
+    __gtProdGuardWarned__?: boolean;
+  }
+}
+
+export default function GTProdGuardScript() {
+  if (!GT_PROD_GUARD_ENABLED) {
+    return null;
+  }
+
+  return (
+    <Script id="gt-prod-guard" strategy="beforeInteractive">
+      {GT_PROD_GUARD_SCRIPT}
+    </Script>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable beforeInteractive script that guards DOM removeChild/insertBefore calls and warns once when skipping invalid operations
- wire the guard into the root and route layouts so it loads when NEXT_PUBLIC_GT_PROD_GUARD=true

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f1d0daacd883279f74d20eb3cd45e6