### PR TITLE
Refresh search results when clearing search input

### DIFF
--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -14,7 +14,12 @@ import {
 } from "next/navigation";
 import Link from "next/link";
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
-import { LOCATION_ROUTE, SEARCH_PARAM, SearchParams } from "./common";
+import {
+  LAST_SET_PARAMS_COOKIE_NAME,
+  LOCATION_ROUTE,
+  SEARCH_PARAM,
+  SearchParams,
+} from "./common";
 import {
   getUrlWithNewFilterParameter,
   getUrlWithoutFilterParameter,
@@ -26,6 +31,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 import { SearchContext, SearchContextType } from "./search-context";
 import { PreviousParams } from "./get-previous-params";
 import { usePreviousParamsOnClient } from "./use-previous-params-client";
+import { useCookies } from "next-client-cookies";
 
 function SearchPanel({
   currentSearch,
@@ -152,6 +158,7 @@ export default function SearchForm() {
         searchParams:
           convertReadonlyURLSearchParamsToSearchParams(searchParams),
       };
+  const cookies = useCookies();
 
   useEffect(() => {
     setSearch(
@@ -164,10 +171,23 @@ export default function SearchForm() {
   function clearSearch() {
     setSearch(null);
     setShowMapViewOnMobile(false);
+    const nextSearchParams = {
+      ...(paramsToUseForNextUrl.searchParams || {}),
+    } as SearchParams;
+    delete nextSearchParams[SEARCH_PARAM];
+
+    cookies.set(
+      LAST_SET_PARAMS_COOKIE_NAME,
+      JSON.stringify({
+        params: paramsToUseForNextUrl.params,
+        searchParams: nextSearchParams,
+      }),
+    );
+
     router.push(
       getUrlWithoutFilterParameter(
         paramsToPathname(paramsToUseForNextUrl.params),
-        paramsToUseForNextUrl.searchParams,
+        nextSearchParams,
         SEARCH_PARAM,
       ),
     );

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -162,7 +162,7 @@ export default function SearchForm() {
   }, [setSearch, searchParamFromQuery, searchParamFromCookie]);
 
   function clearSearch() {
-    setSearch("");
+    setSearch(null);
     setShowMapViewOnMobile(false);
     router.push(
       getUrlWithoutFilterParameter(
@@ -171,14 +171,17 @@ export default function SearchForm() {
         SEARCH_PARAM,
       ),
     );
+    router.refresh();
   }
 
   function doSetSearch(e: ChangeEvent) {
-    setSearch((e.target as HTMLFormElement).value);
-
-    if ((e.target as HTMLFormElement).value === "") {
+    const nextValue = (e.target as HTMLFormElement).value;
+    if (nextValue === "") {
       clearSearch();
+      return;
     }
+
+    setSearch(nextValue);
   }
 
   function handleFocus(e: React.FocusEvent<HTMLInputElement>) {


### PR DESCRIPTION
## Summary
- reset the search context to null when clearing the search bar
- push the URL without the search parameter and force a router refresh when clearing
- ensure onChange short-circuits to the clear helper when the input becomes empty

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68fb752d85f083278c45b58a503dc174