### PR TITLE
Fix search clear action to refresh results

### DIFF
--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -19,6 +19,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { flushSync } from "react-dom";
 import { LOCATION_ROUTE, SEARCH_PARAM, SearchParams } from "./common";
 import {
   getUrlWithNewFilterParameter,
@@ -169,7 +170,9 @@ export default function SearchForm() {
       return;
     }
 
-    setSearch(null);
+    flushSync(() => {
+      setSearch(null);
+    });
     setShowMapViewOnMobile(false);
 
     const nextUrl = getUrlWithoutFilterParameter(

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -12,8 +12,13 @@ import {
   useRouter,
   useSearchParams,
 } from "next/navigation";
-import Link from "next/link";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, {
+  ChangeEvent,
+  startTransition,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { LOCATION_ROUTE, SEARCH_PARAM, SearchParams } from "./common";
 import {
   getUrlWithNewFilterParameter,
@@ -160,15 +165,23 @@ export default function SearchForm() {
   }, [setSearch, searchParamFromQuery, searchParamFromCookie]);
 
   function clearSearch() {
+    if (!search) {
+      return;
+    }
+
     setSearch(null);
     setShowMapViewOnMobile(false);
+
     const nextUrl = getUrlWithoutFilterParameter(
       paramsToPathname(paramsToUseForNextUrl.params),
       paramsToUseForNextUrl.searchParams,
       SEARCH_PARAM,
     );
-    router.push(nextUrl);
-    router.refresh();
+
+    router.replace(nextUrl);
+    startTransition(() => {
+      router.refresh();
+    });
   }
 
   function doSetSearch(e: ChangeEvent) {
@@ -232,16 +245,14 @@ export default function SearchForm() {
           value={search || ""}
         />
         {search ? (
-          <Link
+          <button
+            type="button"
             onClick={clearSearch}
-            href={getUrlWithoutFilterParameter(
-              paramsToPathname(paramsToUseForNextUrl.params),
-              paramsToUseForNextUrl.searchParams,
-              SEARCH_PARAM,
-            )}
+            aria-label="Clear search"
+            className="p-0"
           >
             <XMarkIcon className="w-5 h-5 text-black" />
-          </Link>
+          </button>
         ) : undefined}
       </form>
       {inputHasFocus && search ? (

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -160,23 +160,26 @@ export default function SearchForm() {
   }, [setSearch, searchParamFromQuery, searchParamFromCookie]);
 
   function clearSearch() {
-    setSearch("");
+    setSearch(null);
     setShowMapViewOnMobile(false);
-    router.push(
-      getUrlWithoutFilterParameter(
-        paramsToPathname(paramsToUseForNextUrl.params),
-        paramsToUseForNextUrl.searchParams,
-        SEARCH_PARAM,
-      ),
+    const nextUrl = getUrlWithoutFilterParameter(
+      paramsToPathname(paramsToUseForNextUrl.params),
+      paramsToUseForNextUrl.searchParams,
+      SEARCH_PARAM,
     );
+    router.push(nextUrl);
+    router.refresh();
   }
 
   function doSetSearch(e: ChangeEvent) {
-    setSearch((e.target as HTMLFormElement).value);
+    const value = (e.target as HTMLFormElement).value;
 
-    if ((e.target as HTMLFormElement).value === "") {
+    if (value === "") {
       clearSearch();
+      return;
     }
+
+    setSearch(value);
   }
 
   function handleFocus(e: React.FocusEvent<HTMLInputElement>) {


### PR DESCRIPTION
## Summary
- ensure clearing the search field resets the shared search state
- navigate to the searchless URL and force a refresh so results update after clearing
- avoid redundant state updates when the search input becomes empty

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69075decc054832f9f64969cc881a90d