### PR TITLE
Restrict nearby redirect to top-level service routes

### DIFF
--- a/src/components/__tests__/nearby-redirect.test.ts
+++ b/src/components/__tests__/nearby-redirect.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  shouldAutoRedirectToNearby,
+  shouldRedirectToNearbyPath,
+} from "../nearby-redirect";
+
+test("shouldRedirectToNearbyPath allows all resource index routes", () => {
+  assert.equal(shouldRedirectToNearbyPath("/locations"), true);
+  assert.equal(shouldRedirectToNearbyPath("/shelters-housing"), true);
+  assert.equal(shouldRedirectToNearbyPath("/food"), true);
+  assert.equal(shouldRedirectToNearbyPath("/clothing"), true);
+  assert.equal(shouldRedirectToNearbyPath("/personal-care"), true);
+  assert.equal(shouldRedirectToNearbyPath("/health-care"), true);
+  assert.equal(shouldRedirectToNearbyPath("/other-services"), true);
+  assert.equal(shouldRedirectToNearbyPath("/legal-services"), true);
+  assert.equal(shouldRedirectToNearbyPath("/mental-health"), true);
+  assert.equal(shouldRedirectToNearbyPath("/employment"), true);
+});
+
+test("shouldRedirectToNearbyPath rejects detail and unknown routes", () => {
+  assert.equal(
+    shouldRedirectToNearbyPath(
+      "/locations/roman-catholic-archdiocese-of-newark-rcan-629-clinton-ave",
+    ),
+    false,
+  );
+  assert.equal(shouldRedirectToNearbyPath("/about-us"), false);
+  assert.equal(shouldRedirectToNearbyPath(null), false);
+});
+
+test("shouldRedirectToNearbyPath normalizes trailing slash", () => {
+  assert.equal(shouldRedirectToNearbyPath("/locations/"), true);
+  assert.equal(shouldRedirectToNearbyPath("/locations/slug/"), false);
+});
+
+test("shouldAutoRedirectToNearby enforces all redirect guards", () => {
+  assert.equal(
+    shouldAutoRedirectToNearby({
+      pathname: "/locations",
+      sortBy: null,
+      searchText: null,
+      isLocationDetail: false,
+    }),
+    true,
+  );
+
+  assert.equal(
+    shouldAutoRedirectToNearby({
+      pathname: "/locations",
+      sortBy: "nearby",
+      searchText: null,
+      isLocationDetail: false,
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldAutoRedirectToNearby({
+      pathname: "/locations",
+      sortBy: null,
+      searchText: "soup kitchen",
+      isLocationDetail: false,
+    }),
+    false,
+  );
+
+  assert.equal(
+    shouldAutoRedirectToNearby({
+      pathname: "/locations",
+      sortBy: null,
+      searchText: null,
+      isLocationDetail: true,
+    }),
+    false,
+  );
+});

--- a/src/components/__tests__/nearby-redirect.test.ts
+++ b/src/components/__tests__/nearby-redirect.test.ts
@@ -35,6 +35,34 @@ test("shouldRedirectToNearbyPath normalizes trailing slash", () => {
   assert.equal(shouldRedirectToNearbyPath("/locations/slug/"), false);
 });
 
+test("shouldRedirectToNearbyPath allows locale-prefixed index routes", () => {
+  assert.equal(shouldRedirectToNearbyPath("/en/locations"), true);
+  assert.equal(shouldRedirectToNearbyPath("/en-US/food"), true);
+  assert.equal(shouldRedirectToNearbyPath("/es/mental-health"), true);
+  assert.equal(
+    shouldRedirectToNearbyPath("/en/locations/roman-catholic-archdiocese"),
+    false,
+  );
+});
+
+test("shouldRedirectToNearbyPath allows basePath-prefixed index routes", () => {
+  const previous = process.env.NEXT_PUBLIC_BASE_PATH;
+  process.env.NEXT_PUBLIC_BASE_PATH = "app";
+
+  assert.equal(shouldRedirectToNearbyPath("/app/locations"), true);
+  assert.equal(shouldRedirectToNearbyPath("/app/other-services/"), true);
+  assert.equal(
+    shouldRedirectToNearbyPath("/app/locations/roman-catholic-archdiocese"),
+    false,
+  );
+
+  if (previous === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  } else {
+    process.env.NEXT_PUBLIC_BASE_PATH = previous;
+  }
+});
+
 test("shouldAutoRedirectToNearby enforces all redirect guards", () => {
   assert.equal(
     shouldAutoRedirectToNearby({

--- a/src/components/__tests__/nearby-redirect.test.ts
+++ b/src/components/__tests__/nearby-redirect.test.ts
@@ -63,6 +63,25 @@ test("shouldRedirectToNearbyPath allows basePath-prefixed index routes", () => {
   }
 });
 
+test("shouldRedirectToNearbyPath allows basePath and locale prefixed index routes", () => {
+  const previous = process.env.NEXT_PUBLIC_BASE_PATH;
+  process.env.NEXT_PUBLIC_BASE_PATH = "app";
+
+  assert.equal(shouldRedirectToNearbyPath("/app/en/locations"), true);
+  assert.equal(shouldRedirectToNearbyPath("/app/en-US/food/"), true);
+  assert.equal(shouldRedirectToNearbyPath("/app/es/mental-health"), true);
+  assert.equal(
+    shouldRedirectToNearbyPath("/app/en/locations/roman-catholic-archdiocese"),
+    false,
+  );
+
+  if (previous === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  } else {
+    process.env.NEXT_PUBLIC_BASE_PATH = previous;
+  }
+});
+
 test("shouldAutoRedirectToNearby enforces all redirect guards", () => {
   assert.equal(
     shouldAutoRedirectToNearby({

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -241,9 +241,10 @@ function MapWrapper({
       // then by default route to nearby
       const sortBy = searchParams?.get(SORT_BY_QUERY_PARAM);
       const searchText = searchParams?.get(SEARCH_PARAM);
+      const currentPathname = window.location.pathname;
       if (
         shouldAutoRedirectToNearby({
-          pathname,
+          pathname: currentPathname,
           sortBy,
           searchText,
           isLocationDetail: !!locationDetailStub,
@@ -251,7 +252,7 @@ function MapWrapper({
       ) {
         router.push(
           getUrlWithNewFilterParameter(
-            pathname,
+            currentPathname,
             searchParams,
             SORT_BY_QUERY_PARAM,
             NEARBY_SORT_BY_VALUE,

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -41,6 +41,16 @@ function isMobile(): boolean {
 
 const MAX_NUM_LOCATIONS_TO_INCLUDE_IN_BOUNDS = 20;
 
+const ROUTES_TO_REDIRECT_TO_NEARBY = new Set([
+  "/locations",
+  "/shelters-housing",
+  "/food",
+  "/clothing",
+  "/personal-care",
+  "/health-care",
+  "/other-services",
+]);
+
 const GOOGLE_MAPS_API_KEY = (
   process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string
 ).toString();
@@ -73,6 +83,16 @@ function calculateDistanceInMiles(
 
 function toRad(value: number): number {
   return (value * Math.PI) / 180;
+}
+
+function shouldRedirectToNearbyPath(pathname: string | null): boolean {
+  if (!pathname) {
+    return false;
+  }
+  const normalizedPath = pathname.endsWith("/")
+    ? pathname.slice(0, -1)
+    : pathname;
+  return ROUTES_TO_REDIRECT_TO_NEARBY.has(normalizedPath);
 }
 
 interface SimplifiedLocationDataWithDistance extends SimplifiedLocationData {
@@ -240,7 +260,12 @@ function MapWrapper({
       // then by default route to nearby
       const sortBy = searchParams?.get(SORT_BY_QUERY_PARAM);
       const searchText = searchParams?.get(SEARCH_PARAM);
-      if (!sortBy && !locationDetailStub && !searchText) {
+      if (
+        !sortBy &&
+        !locationDetailStub &&
+        !searchText &&
+        shouldRedirectToNearbyPath(pathname)
+      ) {
         router.push(
           getUrlWithNewFilterParameter(
             pathname,

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -34,22 +34,13 @@ import {
   GeoCoordinatesContextType,
 } from "./geo-context";
 import { useFilters, useViewStore } from "@/lib/store";
+import { shouldAutoRedirectToNearby } from "./nearby-redirect";
 
 function isMobile(): boolean {
   return window.innerWidth <= 768;
 }
 
 const MAX_NUM_LOCATIONS_TO_INCLUDE_IN_BOUNDS = 20;
-
-const ROUTES_TO_REDIRECT_TO_NEARBY = new Set([
-  "/locations",
-  "/shelters-housing",
-  "/food",
-  "/clothing",
-  "/personal-care",
-  "/health-care",
-  "/other-services",
-]);
 
 const GOOGLE_MAPS_API_KEY = (
   process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string
@@ -83,16 +74,6 @@ function calculateDistanceInMiles(
 
 function toRad(value: number): number {
   return (value * Math.PI) / 180;
-}
-
-function shouldRedirectToNearbyPath(pathname: string | null): boolean {
-  if (!pathname) {
-    return false;
-  }
-  const normalizedPath = pathname.endsWith("/")
-    ? pathname.slice(0, -1)
-    : pathname;
-  return ROUTES_TO_REDIRECT_TO_NEARBY.has(normalizedPath);
 }
 
 interface SimplifiedLocationDataWithDistance extends SimplifiedLocationData {
@@ -261,10 +242,12 @@ function MapWrapper({
       const sortBy = searchParams?.get(SORT_BY_QUERY_PARAM);
       const searchText = searchParams?.get(SEARCH_PARAM);
       if (
-        !sortBy &&
-        !locationDetailStub &&
-        !searchText &&
-        shouldRedirectToNearbyPath(pathname)
+        shouldAutoRedirectToNearby({
+          pathname,
+          sortBy,
+          searchText,
+          isLocationDetail: !!locationDetailStub,
+        })
       ) {
         router.push(
           getUrlWithNewFilterParameter(

--- a/src/components/nearby-redirect.ts
+++ b/src/components/nearby-redirect.ts
@@ -4,14 +4,50 @@ const ROUTES_TO_REDIRECT_TO_NEARBY = new Set(
   RESOURCE_ROUTES.map((route) => `/${route}`),
 );
 
+function trimTrailingSlashes(pathname: string): string {
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+function isLocaleSegment(segment: string): boolean {
+  return /^[a-z]{2}(?:-[a-z]{2})?$/i.test(segment);
+}
+
+function removeKnownPrefix(pathname: string): string {
+  const normalizedPath = trimTrailingSlashes(pathname);
+  const segments = normalizedPath.split("/").filter(Boolean);
+
+  if (!segments.length) {
+    return normalizedPath;
+  }
+
+  const nextPublicBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim().replace(
+    /^\/+|\/+$/g,
+    "",
+  );
+
+  if (nextPublicBasePath && segments[0] === nextPublicBasePath) {
+    return `/${segments.slice(1).join("/") || ""}` || "/";
+  }
+
+  if (isLocaleSegment(segments[0])) {
+    return `/${segments.slice(1).join("/") || ""}` || "/";
+  }
+
+  return normalizedPath;
+}
+
 export function shouldRedirectToNearbyPath(pathname: string | null): boolean {
   if (!pathname) {
     return false;
   }
-  const normalizedPath = pathname.endsWith("/")
-    ? pathname.slice(0, -1)
-    : pathname;
-  return ROUTES_TO_REDIRECT_TO_NEARBY.has(normalizedPath);
+
+  const normalizedPath = trimTrailingSlashes(pathname);
+  const deprefixedPath = removeKnownPrefix(normalizedPath);
+
+  return (
+    ROUTES_TO_REDIRECT_TO_NEARBY.has(normalizedPath) ||
+    ROUTES_TO_REDIRECT_TO_NEARBY.has(deprefixedPath)
+  );
 }
 
 export function shouldAutoRedirectToNearby({

--- a/src/components/nearby-redirect.ts
+++ b/src/components/nearby-redirect.ts
@@ -1,0 +1,34 @@
+import { RESOURCE_ROUTES } from "./common";
+
+const ROUTES_TO_REDIRECT_TO_NEARBY = new Set(
+  RESOURCE_ROUTES.map((route) => `/${route}`),
+);
+
+export function shouldRedirectToNearbyPath(pathname: string | null): boolean {
+  if (!pathname) {
+    return false;
+  }
+  const normalizedPath = pathname.endsWith("/")
+    ? pathname.slice(0, -1)
+    : pathname;
+  return ROUTES_TO_REDIRECT_TO_NEARBY.has(normalizedPath);
+}
+
+export function shouldAutoRedirectToNearby({
+  pathname,
+  sortBy,
+  searchText,
+  isLocationDetail,
+}: {
+  pathname: string | null;
+  sortBy: string | null;
+  searchText: string | null;
+  isLocationDetail: boolean;
+}): boolean {
+  return (
+    !sortBy &&
+    !searchText &&
+    !isLocationDetail &&
+    shouldRedirectToNearbyPath(pathname)
+  );
+}

--- a/src/components/nearby-redirect.ts
+++ b/src/components/nearby-redirect.ts
@@ -25,15 +25,22 @@ function removeKnownPrefix(pathname: string): string {
     "",
   );
 
-  if (nextPublicBasePath && segments[0] === nextPublicBasePath) {
-    return `/${segments.slice(1).join("/") || ""}` || "/";
+  let didRemovePrefix = true;
+  while (segments.length && didRemovePrefix) {
+    didRemovePrefix = false;
+
+    if (nextPublicBasePath && segments[0] === nextPublicBasePath) {
+      segments.shift();
+      didRemovePrefix = true;
+    }
+
+    if (segments.length && isLocaleSegment(segments[0])) {
+      segments.shift();
+      didRemovePrefix = true;
+    }
   }
 
-  if (isLocaleSegment(segments[0])) {
-    return `/${segments.slice(1).join("/") || ""}` || "/";
-  }
-
-  return normalizedPath;
+  return `/${segments.join("/") || ""}` || "/";
 }
 
 export function shouldRedirectToNearbyPath(pathname: string | null): boolean {


### PR DESCRIPTION
### Motivation
- The geolocation flow previously auto-redirected to `?sortBy=nearby` regardless of the current route, causing unwanted redirects from location detail pages like `/locations/<slug>`. 
- The goal is to only apply the automatic `sortBy=nearby` when the user is on a top-level service or locations index page.

### Description
- Added an explicit allowlist `ROUTES_TO_REDIRECT_TO_NEARBY` containing the top-level routes that are eligible for the auto-redirect to nearby.  
- Added `shouldRedirectToNearbyPath()` which normalizes trailing slashes and checks the current `pathname` against the allowlist.  
- Updated the geolocation refresh callback in `src/components/map.tsx` to require `shouldRedirectToNearbyPath(pathname)` before pushing the `sortBy=nearby` parameter, preventing redirects on nested/detail routes.  
- Changes are localized to `src/components/map.tsx` and do not change other routing behavior.

### Testing
- Ran `npm run check-types` (TypeScript compile check) and it completed successfully.  
- Ran `npm run lint` (ESLint via `next lint`) and it completed successfully; it reported existing non-blocking warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae3acaacd483278537b1a89b76871a)