### PR TITLE
Redesign requirement exclusion filters

### DIFF
--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -336,9 +336,9 @@ export interface YourPeerParsedRequestParams {
 }
 
 export interface ParsedRequirements {
-  noRequirement: boolean;
-  referralRequired: boolean;
-  membershipRequired: boolean;
+  onlyServicesWithNoRequirements: boolean;
+  excludeReferralLetter: boolean;
+  excludeRegisteredClientOnly: boolean;
 }
 
 export interface ParsedAmenities {
@@ -496,13 +496,13 @@ export function parseRequest({
         ? (searchParams[CLOTHING_PARAM] as ClothingValues)
         : (parsedSubCategory as ClothingValues),
     [REQUIREMENT_PARAM]: {
-      noRequirement: parsedRequirements.includes(
+      onlyServicesWithNoRequirements: parsedRequirements.includes(
         REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE,
       ),
-      referralRequired: parsedRequirements.includes(
+      excludeReferralLetter: parsedRequirements.includes(
         REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE,
       ),
-      membershipRequired: parsedRequirements.includes(
+      excludeRegisteredClientOnly: parsedRequirements.includes(
         REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE,
       ),
     },

--- a/src/components/filters-header.tsx
+++ b/src/components/filters-header.tsx
@@ -108,11 +108,11 @@ export default function FiltersHeader({
 
   const renderRequirementText = (text: string) => {
     if (text === REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE)
-      return "Referral letter";
+      return "Exclude referral letter";
     if (text === REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE)
-      return "Registered client only";
+      return "Exclude registered client only";
 
-    return "No Requirements";
+    return "Only services with no requirements";
   };
 
   const openFiltersPopup = useFilters((state) => state.open);
@@ -385,7 +385,7 @@ export default function FiltersHeader({
 
             {parsedRequirementParam.length > 1 ? (
               <TranslatableText
-                text={`${parsedRequirementParam.length} Requirements`}
+                text={`${parsedRequirementParam.length} exclusions`}
                 className="leading-3 truncate"
               />
             ) : (

--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -28,6 +28,9 @@ import {
   PERSONAL_CARE_CATEGORY,
   REQUIREMENT_PARAM,
   REQUIREMENT_PARAM_CANONICAL_ORDERING,
+  REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE,
+  REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE,
+  REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE,
   RequirementValue,
   RouteParams,
   SEARCH_PARAM,
@@ -216,19 +219,29 @@ export function getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
     currentRequirementValue,
   );
 
-  const newParsedRequirements = addRequirementType
-    ? !parsedRequirements.includes(newRequirementTypeToAddOrRemove)
-      ? parsedRequirements
-          .concat(newRequirementTypeToAddOrRemove)
-          .sort(
-            (a, b) =>
-              REQUIREMENT_PARAM_CANONICAL_ORDERING.indexOf(a) -
-              REQUIREMENT_PARAM_CANONICAL_ORDERING.indexOf(b),
-          )
-      : parsedRequirements
-    : parsedRequirements.filter(
-        (requirement) => requirement !== newRequirementTypeToAddOrRemove,
-      );
+  const newParsedRequirements =
+    newRequirementTypeToAddOrRemove === REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE
+      ? addRequirementType
+        ? [
+            REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE,
+            REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE,
+          ]
+        : []
+      : addRequirementType
+        ? !parsedRequirements.includes(newRequirementTypeToAddOrRemove)
+          ? parsedRequirements
+              .concat(newRequirementTypeToAddOrRemove)
+              .sort(
+                (a, b) =>
+                  REQUIREMENT_PARAM_CANONICAL_ORDERING.indexOf(a) -
+                  REQUIREMENT_PARAM_CANONICAL_ORDERING.indexOf(b),
+              )
+          : parsedRequirements
+        : parsedRequirements.filter(
+            (requirement) =>
+              requirement !== newRequirementTypeToAddOrRemove &&
+              requirement !== REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE,
+          );
 
   if (newParsedRequirements.length) {
     const serializedNewParsedRequirements = newParsedRequirements.join(" ");

--- a/src/components/requirements-fieldset.tsx
+++ b/src/components/requirements-fieldset.tsx
@@ -24,19 +24,21 @@ import { useNormalizedSearchParams } from "./use-normalized-search-params";
 const options = [
   {
     value: REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE,
-    label: "No requirements",
+    label: "Only show services with no requirements",
+    description:
+      "Excludes services that require a referral letter or registered-client status.",
   },
   {
     value: REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE,
-    label: "Referral letter",
+    label: "Exclude referral letter",
     description:
-      "You must bring a letter from another service provider stating that you require this service.",
+      "Excludes services that require a referral letter from another service provider.",
   },
   {
     value: REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE,
-    label: "Registered client only",
+    label: "Exclude registered client only",
     description:
-      "You must be a registered client of their organization to access their services.",
+      "Excludes services that are only available to registered clients.",
   },
 ];
 
@@ -56,16 +58,32 @@ export function RequirementFieldset() {
   );
 
   useEffect(() => {
-    setSelected(parsedRequirementParam);
+    setSelected(
+      parsedRequirementParam.includes(REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE)
+        ? [
+            REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE,
+            REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE,
+          ]
+        : parsedRequirementParam,
+    );
   }, [parsedRequirementParam]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value as RequirementValue;
-    setSelected((prev) =>
-      prev.includes(value)
-        ? prev.filter((item) => item !== value)
-        : [...prev, value],
-    );
+    setSelected((prev) => {
+      if (value === REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE) {
+        return e.target.checked
+          ? [
+              REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE,
+              REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE,
+            ]
+          : [];
+      }
+
+      return e.target.checked
+        ? [...prev, value]
+        : prev.filter((item) => item !== value);
+    });
 
     setLoading(true);
     router.push(
@@ -94,7 +112,12 @@ export function RequirementFieldset() {
               name="requirementType"
               className="w-5 h-5 text-primary !border-dark !border ring-dark focus:ring-dark"
               value={option.value}
-              checked={selected.includes(option.value as RequirementValue)}
+              checked={
+                option.value === REQUIREMENT_PARAM_NO_REQUIREMENTS_VALUE
+                  ? selected.includes(REQUIREMENT_PARAM_REFERRAL_LETTER_VALUE) &&
+                    selected.includes(REQUIREMENT_PARAM_REGISTERED_CLIENT_VALUE)
+                  : selected.includes(option.value as RequirementValue)
+              }
               onChange={handleChange}
             />
             <div className="text-xs text-dark mt-0.5">

--- a/src/components/streetlives-api-service.ts
+++ b/src/components/streetlives-api-service.ts
@@ -63,9 +63,9 @@ export async function fetchLocationsData<T extends SimplifiedLocationData>({
   pageSize,
   taxonomies = null,
   taxonomySpecificAttributes = null,
-  noRequirement,
-  referralRequired,
-  membershipRequired,
+  onlyServicesWithNoRequirements,
+  excludeReferralLetter,
+  excludeRegisteredClientOnly,
   open = false,
   search = undefined,
   aiSearch = false,
@@ -82,9 +82,9 @@ export async function fetchLocationsData<T extends SimplifiedLocationData>({
   pageSize?: number;
   taxonomies: string[] | null;
   taxonomySpecificAttributes?: string[] | null;
-  noRequirement?: boolean;
-  referralRequired?: boolean;
-  membershipRequired?: boolean;
+  onlyServicesWithNoRequirements?: boolean;
+  excludeReferralLetter?: boolean;
+  excludeRegisteredClientOnly?: boolean;
   open?: boolean | null;
   search?: string | null;
   aiSearch?: boolean;
@@ -124,17 +124,21 @@ export async function fetchLocationsData<T extends SimplifiedLocationData>({
         .join("&");
   }
 
-  // one of these needs to be selected to apply filter logic
-  if (noRequirement || referralRequired || membershipRequired) {
-    if (noRequirement) {
-      if (!referralRequired) {
+  // Requirement filters exclude services with the selected requirements.
+  if (
+    onlyServicesWithNoRequirements ||
+    excludeReferralLetter ||
+    excludeRegisteredClientOnly
+  ) {
+    if (onlyServicesWithNoRequirements) {
+      query_url += `&referralRequired=false&membership=false`;
+    } else {
+      if (excludeReferralLetter) {
         query_url += `&referralRequired=false`;
       }
-      if (!membershipRequired) {
+      if (excludeRegisteredClientOnly) {
         query_url += `&membership=false`;
       }
-    } else {
-      query_url += `&referralRequired=${referralRequired}&membership=${membershipRequired}`;
     }
   }
 
@@ -200,9 +204,9 @@ function recursiveParseUpdatedAt<T extends SimplifiedLocationData>(
 export async function getSimplifiedLocationData({
   taxonomies,
   taxonomySpecificAttributes = null,
-  noRequirement,
-  referralRequired,
-  membershipRequired,
+  onlyServicesWithNoRequirements,
+  excludeReferralLetter,
+  excludeRegisteredClientOnly,
   open = false,
   search = undefined,
   aiSearch = false,
@@ -215,9 +219,9 @@ export async function getSimplifiedLocationData({
   pageSize?: number;
   taxonomies: string[] | null;
   taxonomySpecificAttributes: string[] | null;
-  noRequirement?: boolean;
-  referralRequired?: boolean;
-  membershipRequired?: boolean;
+  onlyServicesWithNoRequirements?: boolean;
+  excludeReferralLetter?: boolean;
+  excludeRegisteredClientOnly?: boolean;
   open?: boolean | null;
   search?: string | null;
   aiSearch?: boolean;
@@ -231,9 +235,9 @@ export async function getSimplifiedLocationData({
     await fetchLocationsData<SimplifiedLocationData>({
       taxonomies,
       taxonomySpecificAttributes,
-      noRequirement,
-      referralRequired,
-      membershipRequired,
+      onlyServicesWithNoRequirements,
+      excludeReferralLetter,
+      excludeRegisteredClientOnly,
       open,
       search,
       aiSearch,
@@ -251,9 +255,9 @@ export async function getFullLocationData({
   pageSize = DEFAULT_PAGE_SIZE,
   taxonomies,
   taxonomySpecificAttributes,
-  noRequirement,
-  referralRequired,
-  membershipRequired,
+  onlyServicesWithNoRequirements,
+  excludeReferralLetter,
+  excludeRegisteredClientOnly,
   open = false,
   search = undefined,
   aiSearch = false,
@@ -269,9 +273,9 @@ export async function getFullLocationData({
   pageSize?: number;
   taxonomies: string[] | null;
   taxonomySpecificAttributes?: string[] | null;
-  noRequirement: boolean;
-  referralRequired: boolean;
-  membershipRequired: boolean;
+  onlyServicesWithNoRequirements: boolean;
+  excludeReferralLetter: boolean;
+  excludeRegisteredClientOnly: boolean;
   open?: boolean | null;
   search?: string | null;
   aiSearch?: boolean;
@@ -288,9 +292,9 @@ export async function getFullLocationData({
     pageSize,
     taxonomies,
     taxonomySpecificAttributes,
-    noRequirement,
-    referralRequired,
-    membershipRequired,
+    onlyServicesWithNoRequirements,
+    excludeReferralLetter,
+    excludeRegisteredClientOnly,
     open,
     search,
     aiSearch,

--- a/src/components/translations/russian.tsx
+++ b/src/components/translations/russian.tsx
@@ -99,12 +99,23 @@ const translations: Record<string, string> = {
   Professional: "Рабочая",
   "Requirement type": "Тип условия ограничивающего доступ к услуге",
   "No requirements": "Услуга доступна всем без ограничений",
+  "Only show services with no requirements":
+    "Показывать только услуги без требований",
+  "Excludes services that require a referral letter or registered-client status.":
+    "Исключает услуги, для которых нужно письмо-направление или статус зарегистрированного клиента.",
   "Referral letter": "Письмо-направление",
+  "Exclude referral letter": "Исключить услуги с письмом-направлением",
   "You must bring a letter from another service provider stating that you require this service.":
     "Вам необходимо принести письмо-направление от другой организации, подтверждающее, что Вам необходима эта услуга",
+  "Excludes services that require a referral letter from another service provider.":
+    "Исключает услуги, для которых нужно письмо-направление от другого поставщика услуг.",
   "Registered client only": "Для зарегистрированных клиентов организации",
+  "Exclude registered client only":
+    "Исключить услуги только для зарегистрированных клиентов",
   "You must be a registered client of their organization to access their services.":
     "Для доступа к услугам Вы должны быть зарегистрированным клиентом этой организации",
+  "Excludes services that are only available to registered clients.":
+    "Исключает услуги, доступные только зарегистрированным клиентам.",
   Amenities: "Удобства",
   Toiletries: "Туалетные принадлежности",
   Restrooms: "Туалеты",

--- a/tests/unit/filtersPopup.test.ts
+++ b/tests/unit/filtersPopup.test.ts
@@ -140,40 +140,60 @@ describe("getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved", () => {
     ).toThrow("Expected pathname to not be null");
   });
 
-  it("adds a requirement", () => {
+  it("adds an exclusion", () => {
+    const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
+      "/clothing",
+      params(),
+      "referral-letter",
+      true,
+    );
+    expect(url).toBe("/clothing?requirement=referral-letter");
+  });
+
+  it("adds a second exclusion in canonical order", () => {
+    const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
+      "/clothing",
+      params({ requirement: "referral-letter" }),
+      "registered-client",
+      true,
+    );
+    expect(url).toBe("/clothing?requirement=referral-letter+registered-client");
+  });
+
+  it("removes an exclusion", () => {
+    const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
+      "/clothing",
+      params({ requirement: "referral-letter registered-client" }),
+      "referral-letter",
+      false,
+    );
+    expect(url).toBe("/clothing?requirement=registered-client");
+  });
+
+  it("removes the param entirely when the last exclusion is removed", () => {
+    const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
+      "/clothing",
+      params({ requirement: "no" }),
+      "referral-letter",
+      false,
+    );
+    expect(url).toBe("/clothing");
+  });
+
+  it("adds both exclusions when only services with no requirements is selected", () => {
     const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
       "/clothing",
       params(),
       "no",
       true,
     );
-    expect(url).toBe("/clothing?requirement=no");
+    expect(url).toBe("/clothing?requirement=referral-letter+registered-client");
   });
 
-  it("adds a second requirement in canonical order", () => {
+  it("clears all exclusions when only services with no requirements is cleared", () => {
     const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
       "/clothing",
-      params({ requirement: "no" }),
-      "referral-letter",
-      true,
-    );
-    expect(url).toBe("/clothing?requirement=no+referral-letter");
-  });
-
-  it("removes a requirement", () => {
-    const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
-      "/clothing",
-      params({ requirement: "no referral-letter" }),
-      "referral-letter",
-      false,
-    );
-    expect(url).toBe("/clothing?requirement=no");
-  });
-
-  it("removes the param entirely when the last requirement is removed", () => {
-    const url = getUrlWithNewRequirementTypeFilterParameterAddedOrRemoved(
-      "/clothing",
-      params({ requirement: "no" }),
+      params({ requirement: "referral-letter registered-client" }),
       "no",
       false,
     );


### PR DESCRIPTION
## Summary

Redesigns the clothing and personal-care requirement filters to use exclusion-based language and behavior.

- Show all results by default when no requirement filters are selected.
- Rename individual options to “Exclude referral letter” and “Exclude registered client only.”
- Add “Only show services with no requirements” as a master control that selects or clears both exclusions.
- Update filter chips, URL handling, API query construction, and Russian translations.
- Preserve support for existing `?requirement=no` links.

Related to #617 
