### PR TITLE
Restyle AI search toggle button

### DIFF
--- a/src/components/__tests__/search-form-ai-sync.test.tsx
+++ b/src/components/__tests__/search-form-ai-sync.test.tsx
@@ -65,6 +65,13 @@ vi.mock("next/dist/server/web/spec-extension/adapters/request-cookies", () => ({
   ReadonlyRequestCookies: class {},
 }));
 
+// SearchForm renders outside a LanguageTranslationProvider in these tests, so
+// stub out TranslatableText (and its next-client-cookies dependency) with a
+// plain passthrough.
+vi.mock("@/components/translatable-text", () => ({
+  TranslatableText: ({ text }: { text: string }) => text,
+}));
+
 // doSearchSubmit calls window["gtag"]; provide a no-op so tests don't throw.
 Object.defineProperty(window, "gtag", { value: vi.fn(), writable: true });
 

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -7,7 +7,8 @@
 "use client";
 
 import { useFilters, useViewStore } from "@/lib/store";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import { SparklesIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { TranslatableText } from "@/components/translatable-text";
 import {
   ReadonlyURLSearchParams,
   usePathname,
@@ -293,13 +294,14 @@ export default function SearchForm() {
           onClick={toggleAiSearch}
           id="ai_search_toggle"
           title={aiSearchEnabled ? "AI Search on" : "AI Search off"}
-          className={`flex-shrink-0 text-xs font-semibold px-1.5 py-0.5 rounded border transition-colors ${
+          className={`flex-shrink-0 flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full border transition-all duration-200 hover:shadow-[0_0_10px_2px_rgba(255,220,0,0.6)] ${
             aiSearchEnabled
               ? "bg-primary text-black border-primary"
               : "bg-white text-gray-400 border-gray-300"
           }`}
         >
-          AI
+          <SparklesIcon className="w-3.5 h-3.5" />
+          <TranslatableText text="AI mode" />
         </button>
         {search ? (
           <button

--- a/src/components/translations/russian.tsx
+++ b/src/components/translations/russian.tsx
@@ -98,6 +98,7 @@ const translations: Record<string, string> = {
   Casual: "Повседневная",
   Professional: "Рабочая",
   "Requirement type": "Тип условия ограничивающего доступ к услуге",
+  "AI mode": "Режим ИИ",
   "No requirements": "Услуга доступна всем без ограничений",
   "Referral letter": "Письмо-направление",
   "You must bring a letter from another service provider stating that you require this service.":


### PR DESCRIPTION
## Summary
- Added a sparkles icon before the label in the AI search toggle button
- Renamed the button label from "AI" to "AI mode" (with Russian translation)
- Made the button fully rounded and added a glow effect on hover

## Test plan

- [ ] Manually verify the button in the browser (toggle on/off states, hover glow)
